### PR TITLE
Try port discovery to be smarter by using netifaces

### DIFF
--- a/client.py
+++ b/client.py
@@ -24,10 +24,10 @@ else:
 # --- Service Discovery Protocol --- #
 DISCOVERY_PORT = 8081
 DISCOVERY_MESSAGE = b"PYTHON_CHAT_SERVER_DISCOVERY_V1"
-DISCOVERY_TIMEOUT_S = 3
+DISCOVERY_TIMEOUT_S = 5
 # ---------------------------------- #
 
-VERSION = 1.1
+VERSION = "1.1"
 
 console = Console()
 

--- a/client.py
+++ b/client.py
@@ -27,7 +27,7 @@ DISCOVERY_MESSAGE = b"PYTHON_CHAT_SERVER_DISCOVERY_V1"
 DISCOVERY_TIMEOUT_S = 3
 # ---------------------------------- #
 
-VERSION = 1.0
+VERSION = 1.1
 
 console = Console()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 rich
+netifaces

--- a/server.py
+++ b/server.py
@@ -239,13 +239,14 @@ class ChatServer:
                             continue
                     
                     # Generic fallback
-                    targets.update({'<broadcast', '255.255.255.255'})
+                    targets.update({'<broadcast>', '255.255.255.255'})
                     
                     # Send discovery
                     for bcast in targets:
                         try:
                             sock.sendto(DISCOVERY_MESSAGE, (bcast, DISCOVERY_PORT))
-                        except Exception:
+                        except Exception as e:
+                            console.log(f"[dim]Discovery send failed for {bcast}: {e}[/dim]")
                             continue
                     time.sleep(BROADCAST_INTERVAL_S)
                 except Exception as e:

--- a/server.py
+++ b/server.py
@@ -244,6 +244,7 @@ class ChatServer:
                     
                     # Also send to the generic broadcast address as a fallback
                     sock.sendto(DISCOVERY_MESSAGE, ('<broadcast>', DISCOVERY_PORT))
+                    sock.sendto(DISCOVERY_MESSAGE, ('255.255.255.255', DISCOVERY_PORT))
 
                     time.sleep(BROADCAST_INTERVAL_S)
                 except Exception as e:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Service discovery now broadcasts across all available network interfaces for improved device detection on multi-subnet and complex networks.

- Bug Fixes
  - Better handling when interfaces lack broadcast support and added back-off to avoid busy retry loops.

- Chores
  - Discovery timeout increased for more reliable detection.
  - App version updated to 1.1 (reflected in the UI) and a network-interfaces dependency added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->